### PR TITLE
client builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ serde_json = "1.0.53"
 serde_derive = "1.0.110"
 chrono = "0.4.11"
 hmac-sha1 = "0.1.3"
+
+[dev-dependencies]
+wiremock = "0.2.2"

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -1,0 +1,142 @@
+use crate::models::bearer::BearerToken;
+use crate::TwitterAPI;
+use anyhow::Result;
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+
+#[derive(Debug, Default)]
+pub struct ClientBuilder<AccessTokenType, AccessTokenSecretType, ApiKeyType, ApiKeySecretType> {
+    access_token: AccessTokenType,
+    access_token_secret: AccessTokenSecretType,
+    api_key: ApiKeyType,
+    api_secret_key: ApiKeySecretType,
+}
+
+impl ClientBuilder<(), (), (), ()> {
+    pub fn new() -> Self {
+        ClientBuilder {
+            access_token: (),
+            access_token_secret: (),
+            api_key: (),
+            api_secret_key: (),
+        }
+    }
+}
+
+impl ClientBuilder<String, String, String, String> {
+    pub async fn build(self) -> Result<TwitterAPI> {
+        let client = reqwest::Client::new();
+        let bearer = self.get_bearer(&client).await?;
+
+        Ok(TwitterAPI {
+            access_token: self.access_token,
+            access_token_secret: self.access_token_secret,
+            api_key: self.api_key,
+            api_secret_key: self.api_secret_key,
+            bearer,
+            client,
+        })
+    }
+
+    async fn get_bearer(&self, client: &reqwest::Client) -> Result<BearerToken> {
+        let endpoint = "https://api.twitter.com/oauth2/token";
+        let headers = self.setup_header()?;
+
+        // TODO: #8 better error handling
+        let text = client
+            .post(endpoint)
+            .body("grant_type=client_credentials")
+            .headers(headers)
+            .send()
+            .await?
+            .text()
+            .await?;
+
+        let bearer: BearerToken = serde_json::from_str(&text)?;
+        Ok(bearer)
+    }
+
+    fn setup_header(&self) -> Result<HeaderMap<HeaderValue>> {
+        let encoded_keys = base64::encode(&format!("{}:{}", &self.api_key, &self.api_secret_key));
+        let header_auth = format!("Basic {}", encoded_keys);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, header_auth.parse()?);
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/x-www-form-urlencoded"),
+        );
+        Ok(headers)
+    }
+}
+
+impl<AccessTokenType, AccessTokenSecretType, ApiKeyType, ApiKeySecretType>
+    ClientBuilder<AccessTokenType, AccessTokenSecretType, ApiKeyType, ApiKeySecretType>
+{
+    pub fn access_token(
+        self,
+        access_token: impl Into<String>,
+    ) -> ClientBuilder<String, AccessTokenSecretType, ApiKeyType, ApiKeySecretType> {
+        ClientBuilder {
+            access_token: access_token.into(),
+            access_token_secret: self.access_token_secret,
+            api_key: self.api_key,
+            api_secret_key: self.api_secret_key,
+        }
+    }
+
+    pub fn access_token_secret(
+        self,
+        access_token_secret: impl Into<String>,
+    ) -> ClientBuilder<AccessTokenType, String, ApiKeyType, ApiKeySecretType> {
+        ClientBuilder {
+            access_token: self.access_token,
+            access_token_secret: access_token_secret.into(),
+            api_key: self.api_key,
+            api_secret_key: self.api_secret_key,
+        }
+    }
+
+    pub fn api_key(
+        self,
+        api_key: impl Into<String>,
+    ) -> ClientBuilder<AccessTokenType, AccessTokenSecretType, String, ApiKeySecretType> {
+        ClientBuilder {
+            access_token: self.access_token,
+            access_token_secret: self.access_token_secret,
+            api_key: api_key.into(),
+            api_secret_key: self.api_secret_key,
+        }
+    }
+
+    pub fn api_secret_key(
+        self,
+        api_secret_key: impl Into<String>,
+    ) -> ClientBuilder<AccessTokenType, AccessTokenSecretType, ApiKeyType, String> {
+        ClientBuilder {
+            access_token: self.access_token,
+            access_token_secret: self.access_token_secret,
+            api_key: self.api_key,
+            api_secret_key: api_secret_key.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn builder_method_chain() {
+        use super::*;
+        let builder = ClientBuilder::new()
+            .api_key("foo")
+            .access_token_secret("bar")
+            .api_secret_key("baz")
+            .access_token("qux");
+
+        assert_eq!(builder.api_key, "foo");
+        assert_eq!(builder.api_secret_key, "baz");
+        assert_eq!(builder.access_token, "qux");
+        assert_eq!(builder.access_token_secret, "bar");
+    }
+
+    // TODO: build test
+}

--- a/src/client_builder.rs
+++ b/src/client_builder.rs
@@ -3,6 +3,37 @@ use crate::TwitterAPI;
 use anyhow::Result;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 
+/// A `ClientBuilder` can help construct a [`TwitterAPI`] instance with your configuration.
+/// Before calling [`build`] method, you must set four values:
+///
+/// 1. `Access token`
+/// 2. `Access token secret`
+/// 3. `API key`
+/// 4. `API secret key`
+///
+/// The four setter methods can be called with any order.
+///
+/// # Example
+///
+/// ```rust
+/// # async fn doc() -> Result<(), anyhow::Error> {
+/// use kuon::ClientBuilder;
+/// let builder = ClientBuilder::new();
+///
+/// // The order of setter methods can be changed.
+/// let api_client = builder
+///     .access_token("YOUR_ACCESS_TOKEN")
+///     .access_token_secret("YOUR_ACCESS_TOKEN_SECRET")
+///     .api_key("YOUR_API_KEY")
+///     .api_secret_key("YOUR_API_SECRET_KEY")
+///     .build() // This can be called only after all values have been set.
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`TwitterAPI`]: struct.TwitterAPI.html
+/// [`build`]: struct.ClientBuilder.html#method.build
 #[derive(Debug, Default)]
 pub struct ClientBuilder<AccessTokenType, AccessTokenSecretType, ApiKeyType, ApiKeySecretType> {
     access_token: AccessTokenType,
@@ -12,6 +43,11 @@ pub struct ClientBuilder<AccessTokenType, AccessTokenSecretType, ApiKeyType, Api
 }
 
 impl ClientBuilder<(), (), (), ()> {
+    /// Creates a builder instance.
+    ///
+    /// This is exactly equivalent to [`TwitterAPI::builder`].
+    ///
+    /// [`TwitterAPI::builder`]: struct.TwitterAPI.html#method.builder
     pub fn new() -> Self {
         ClientBuilder {
             access_token: (),
@@ -23,6 +59,15 @@ impl ClientBuilder<(), (), (), ()> {
 }
 
 impl ClientBuilder<String, String, String, String> {
+    /// Builds a [`TwitterAPI`] instance with the values you've set.
+    ///
+    /// You can call this method only after the four required values have been set.
+    ///
+    /// # Error
+    ///
+    /// This method fails if there is an error when obtaining a bearer token.
+    ///
+    /// [`TwitterAPI`]: struct.TwitterAPI.html
     pub async fn build(self) -> Result<TwitterAPI> {
         let client = reqwest::Client::new();
         let bearer = self.get_bearer(&client).await?;
@@ -79,6 +124,7 @@ impl ClientBuilder<String, String, String, String> {
 impl<AccessTokenType, AccessTokenSecretType, ApiKeyType, ApiKeySecretType>
     ClientBuilder<AccessTokenType, AccessTokenSecretType, ApiKeyType, ApiKeySecretType>
 {
+    /// Sets the access token.
     pub fn access_token(
         self,
         access_token: impl Into<String>,
@@ -91,6 +137,7 @@ impl<AccessTokenType, AccessTokenSecretType, ApiKeyType, ApiKeySecretType>
         }
     }
 
+    /// Sets the access token secret.
     pub fn access_token_secret(
         self,
         access_token_secret: impl Into<String>,
@@ -103,6 +150,7 @@ impl<AccessTokenType, AccessTokenSecretType, ApiKeyType, ApiKeySecretType>
         }
     }
 
+    /// Sets the api key.
     pub fn api_key(
         self,
         api_key: impl Into<String>,
@@ -115,6 +163,7 @@ impl<AccessTokenType, AccessTokenSecretType, ApiKeyType, ApiKeySecretType>
         }
     }
 
+    /// Sets the api secret key.
     pub fn api_secret_key(
         self,
         api_secret_key: impl Into<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod client_builder;
 mod constants;
 mod models;
 mod request;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod models;
 mod request;
 mod tweets;
 
+pub use client_builder::ClientBuilder;
 pub(crate) use constants::*;
 pub use models::*;
 pub use tweets::*;

--- a/src/models/bearer.rs
+++ b/src/models/bearer.rs
@@ -1,6 +1,6 @@
 use serde_derive::*;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct BearerToken {
     pub access_token: String,
     pub token_type: String,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,5 @@
 mod api_errors;
-mod bearer;
+pub(crate) mod bearer;
 mod result;
 mod tweet;
 mod twitter_api;

--- a/src/models/twitter_api.rs
+++ b/src/models/twitter_api.rs
@@ -1,6 +1,5 @@
+use crate::client_builder::ClientBuilder;
 use crate::models::bearer::BearerToken;
-use anyhow::Result;
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 
 #[derive(Debug, Clone)]
 // TODO: #3 Thinking about naming, it might be better to use TwitterAPI
@@ -14,58 +13,15 @@ pub struct TwitterAPI {
 }
 
 impl TwitterAPI {
-    pub async fn new(
-        api_key: &str,
-        api_secret_key: &str,
-        access_token: &str,
-        access_token_secret: &str,
-    ) -> Result<Self> {
-        let client = reqwest::Client::new();
-        let bearer: BearerToken = Self::get_bearer(api_key, api_secret_key, &client).await?;
-        Ok(Self {
-            access_token: access_token.into(),
-            access_token_secret: access_token_secret.into(),
-            api_key: api_key.into(),
-            api_secret_key: api_secret_key.into(),
-            bearer,
-            client,
-        })
-    }
-
-    async fn get_bearer(
-        api_key: &str,
-        api_secret_key: &str,
-        client: &reqwest::Client,
-    ) -> Result<BearerToken> {
-        let endpoint = "https://api.twitter.com/oauth2/token";
-        let encoded_keys = base64::encode(&format!("{}:{}", api_key, api_secret_key));
-        let header_auth = format!("Basic {}", encoded_keys);
-
-        let mut headers = HeaderMap::new();
-        headers.insert(AUTHORIZATION, header_auth.parse()?);
-        headers.insert(
-            CONTENT_TYPE,
-            HeaderValue::from_static("application/x-www-form-urlencoded"),
-        );
-
-        // TODO: #8 better error handling
-        let text = client
-            .post(endpoint)
-            .body("grant_type=client_credentials")
-            .headers(headers)
-            .send()
-            .await?
-            .text()
-            .await?;
-
-        let bearer: BearerToken = serde_json::from_str(&text)?;
-        Ok(bearer)
+    pub fn builder() -> ClientBuilder<(), (), (), ()> {
+        ClientBuilder::new()
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use anyhow::Result;
 
     #[tokio::test]
     async fn test() -> Result<()> {

--- a/src/models/twitter_api.rs
+++ b/src/models/twitter_api.rs
@@ -13,6 +13,12 @@ pub struct TwitterAPI {
 }
 
 impl TwitterAPI {
+    /// Creates [`ClientBuilder`] that helps construct a configured `TwitterAPI`.
+    ///
+    /// This is exactly equivalent to [`ClientBuilder::new`].
+    ///
+    /// [`ClientBuilder`]: struct.ClientBuilder.html
+    /// [`ClientBuilder::new`]: struct.ClientBuilder.html#method.new
     pub fn builder() -> ClientBuilder<(), (), (), ()> {
         ClientBuilder::new()
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -7,8 +7,13 @@ async fn test() -> Result<()> {
     let api_key = &std::env::var("API_KEY").unwrap();
     let api_secret_key = &std::env::var("API_SECRET_KEY").unwrap();
 
-    let api: kuon::TwitterAPI =
-        kuon::TwitterAPI::new(api_key, api_secret_key, access_token, access_token_secret).await?;
+    let builder = kuon::TwitterAPI::builder()
+        .access_token(access_token)
+        .access_token_secret(access_token_secret)
+        .api_key(api_key)
+        .api_secret_key(api_secret_key);
+
+    let api = builder.build().await?;
 
     let params = maplit::hashmap! { "count" => "15" };
 


### PR DESCRIPTION
In my opinion, it would be better to use the builder pattern for creating `TwitterAPI` instance, so I started implementing that in a type-safe style.

This is currently work in progress. I'll try to add some more tests and documents.