### PR TITLE
:recycle: Fix to allow use of raw requests

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -5,7 +5,7 @@ use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 
 impl TwitterAPI {
-    pub(crate) async fn get<T>(&self, endpoint: &str, params: &HashMap<&str, &str>) -> Result<T>
+    pub async fn get<T>(&self, endpoint: &str, params: &HashMap<&str, &str>) -> Result<T>
     where
         T: DeserializeOwned,
     {
@@ -29,7 +29,7 @@ impl TwitterAPI {
         Ok(result)
     }
 
-    pub(crate) async fn post<T>(&self, endpoint: &str, params: &HashMap<&str, &str>) -> Result<T>
+    pub async fn post<T>(&self, endpoint: &str, params: &HashMap<&str, &str>) -> Result<T>
     where
         T: DeserializeOwned,
     {


### PR DESCRIPTION
To use APIs that are not implemented, `TwitterAPI::get` and `TwitterAPI::post` are now available outside of the crate.