### PR TITLE
Rename request methods and publish raw request methods

### DIFF
--- a/examples/raw_request.rs
+++ b/examples/raw_request.rs
@@ -1,0 +1,17 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use maplit::hashmap;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Please set API_KEY, API_SECRET_KEY, ACCESS_TOKEN, ACCESS_TOKEN_SECRET in environment
+    let api: kuon::TwitterAPI = kuon::TwitterAPI::new_using_env().await?;
+    let url = "https://api.twitter.com/1.1/account/update_profile.json";
+    let res: HashMap<String, String> = api
+        .raw_post(url, &hashmap! { "name" => "new_user_name" })
+        .await?;
+
+    println!("{:?}", res);
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,6 @@ mod users;
 pub use client_builder::ClientBuilder;
 pub(crate) use constants::*;
 pub use models::*;
+pub use request::*;
 pub use tweets::*;
 pub use users::*;

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,7 +5,7 @@ use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 
 impl TwitterAPI {
-    pub async fn get<T>(&self, endpoint: &str, params: &HashMap<&str, &str>) -> Result<T>
+    pub async fn raw_get<T>(&self, endpoint: &str, params: &HashMap<&str, &str>) -> Result<T>
     where
         T: DeserializeOwned,
     {
@@ -29,7 +29,7 @@ impl TwitterAPI {
         Ok(result)
     }
 
-    pub async fn post<T>(&self, endpoint: &str, params: &HashMap<&str, &str>) -> Result<T>
+    pub async fn raw_post<T>(&self, endpoint: &str, params: &HashMap<&str, &str>) -> Result<T>
     where
         T: DeserializeOwned,
     {

--- a/src/tweets/favorite.rs
+++ b/src/tweets/favorite.rs
@@ -6,6 +6,6 @@ impl TwitterAPI {
         let endpoint = "https://api.twitter.com/1.1/favorites/create.json";
         let params = maplit::hashmap! { "id" => id };
 
-        self.post(endpoint, &params).await
+        self.raw_post(endpoint, &params).await
     }
 }

--- a/src/tweets/retweet.rs
+++ b/src/tweets/retweet.rs
@@ -7,6 +7,6 @@ impl TwitterAPI {
         let endpoint = &format!("https://api.twitter.com/1.1/statuses/retweet/{}.json", id);
         let params = maplit::hashmap! {};
 
-        self.post::<RetweetResult>(endpoint, &params).await
+        self.raw_post::<RetweetResult>(endpoint, &params).await
     }
 }

--- a/src/tweets/search.rs
+++ b/src/tweets/search.rs
@@ -7,7 +7,7 @@ impl TwitterAPI {
         let endpoint = "https://api.twitter.com/1.1/search/tweets.json";
         let params = maplit::hashmap! { "q" => query };
 
-        self.get(endpoint, &params).await
+        self.raw_get(endpoint, &params).await
     }
 
     pub async fn search_tweets_with_params(
@@ -19,7 +19,7 @@ impl TwitterAPI {
         let mut params = params.clone();
         params.insert("q", query);
 
-        self.get(endpoint, &params).await
+        self.raw_get(endpoint, &params).await
     }
 
     pub async fn premium_search_30days(
@@ -32,7 +32,7 @@ impl TwitterAPI {
             devenv_name
         );
 
-        self.get(endpoint, &params).await
+        self.raw_get(endpoint, &params).await
     }
 
     pub async fn premium_search_fullarchive(
@@ -45,7 +45,7 @@ impl TwitterAPI {
             devenv_name
         );
 
-        self.get(endpoint, &params).await
+        self.raw_get(endpoint, &params).await
     }
 }
 

--- a/src/tweets/show.rs
+++ b/src/tweets/show.rs
@@ -9,6 +9,6 @@ impl TwitterAPI {
         let id_str: &str = &id.to_string();
         let params = hashmap! { "id" => id_str };
 
-        self.get(endpoint, &params).await
+        self.raw_get(endpoint, &params).await
     }
 }

--- a/src/tweets/tweet.rs
+++ b/src/tweets/tweet.rs
@@ -17,7 +17,7 @@ impl TwitterAPI {
         let endpoint = "https://api.twitter.com/1.1/statuses/update.json";
         let params = maplit::hashmap! { "status" => status };
 
-        self.post(endpoint, &params).await
+        self.raw_post(endpoint, &params).await
     }
 
     pub async fn tweet_with_params(
@@ -29,6 +29,6 @@ impl TwitterAPI {
         let mut params = params.clone();
         params.insert("status", status);
 
-        self.post(endpoint, &params).await
+        self.raw_post(endpoint, &params).await
     }
 }

--- a/src/users/followers.rs
+++ b/src/users/followers.rs
@@ -5,11 +5,11 @@ use std::collections::HashMap;
 impl TwitterAPI {
     pub async fn follwers_ids(&self, params: &HashMap<&str, &str>) -> Result<FollowersIdsResult> {
         let endpoint = "https://api.twitter.com/1.1/followers/ids.json";
-        self.get(endpoint, &params).await
+        self.raw_get(endpoint, &params).await
     }
 
     pub async fn follwers_list(&self, params: &HashMap<&str, &str>) -> Result<FollowersListResult> {
         let endpoint = "https://api.twitter.com/1.1/followers/list.json";
-        self.get(endpoint, &params).await
+        self.raw_get(endpoint, &params).await
     }
 }


### PR DESCRIPTION
I renamed the `get` and `post` methods to `raw_get` and `raw_post` for export.
Also, I added a sample using `raw_post`.