### PR TITLE
fix show_tweet api medhod

### DIFF
--- a/src/tweets/show_tweet.rs
+++ b/src/tweets/show_tweet.rs
@@ -60,6 +60,6 @@ where
         let endpoint = "https://api.twitter.com/1.1/statuses/show.json";
         let params = self.to_hashmap();
 
-        self.api.raw_post(endpoint, &params).await
+        self.api.raw_get(endpoint, &params).await
     }
 }


### PR DESCRIPTION
Hi.
I fixed the API method of `show_tweet` from POST to GET.

Seems that it's not working from [this commit](https://github.com/hppRC/kuon/commit/9b81a5136471aa5514e44ff28da5f4c578979180#diff-605eb071315b63e677e05decc4ad982ab20e66ceee7cee7df10f3dc41ceabc9c).

I confirmed it works after this fix with my API keys .